### PR TITLE
Rewrite based on declaring prop dependencies

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Attributes not rendered on a wrapper component 1`] = `<div />`;
+
+exports[`Attributes passed from wrapper component to element 1`] = `
+<div>
+  <span
+    data-attr="Other custom attr"
+    id="default-id"
+  />
+</div>
+`;
+
+exports[`Attributes rendered on an element 1`] = `
+<div
+  data-name="Default name"
+  id="default-id"
+/>
+`;
+
+exports[`Attributes rendered on an element with parent props 1`] = `
+<div
+  data-name="Custom name"
+  id="custom-id"
+/>
+`;
+
 exports[`Basic conditional rendering with the prop flag 1`] = `
 <div>
   hi

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -25,17 +25,21 @@ exports[`Attributes rendered on an element with parent props 1`] = `
 />
 `;
 
-exports[`Basic conditional rendering with the prop flag 1`] = `
-<div>
-  hi
-</div>
-`;
-
-exports[`Basic conditional rendering without the prop flag 1`] = `null`;
-
 exports[`Classes with a single class 1`] = `
 <div
   className="some-class"
+/>
+`;
+
+exports[`Classes with conditional classes 1`] = `
+<div
+  className="base-class small"
+/>
+`;
+
+exports[`Classes with conditional classes 2`] = `
+<div
+  className="base-class big"
 />
 `;
 
@@ -47,46 +51,91 @@ exports[`Classes with multiple classes 1`] = `
 
 exports[`Classes with no classes 1`] = `<div />`;
 
-exports[`Conditional rendering by function with sum of props greater than 10 1`] = `
-<div>
-  hi
-</div>
-`;
-
-exports[`Conditional rendering by function with sum of props less than 10 1`] = `null`;
-
-exports[`Div with a conditional class gets a single extra class with the prop flag 1`] = `
+exports[`Conditional rendering using a child-function 1`] = `
 <div
-  className="thing thing--big"
+  className="root"
 />
 `;
 
-exports[`Div with a conditional class gets two extra classes without the prop flag 1`] = `
+exports[`Conditional rendering using a child-function 2`] = `
 <div
-  className="thing thing--small small"
-/>
-`;
-
-exports[`Passing props passes props to child components 1`] = `
-<div>
-  <span>
-    a gif
-  </span>
+  className="root"
+>
   <img
-    alt="aw yis"
-    src="awyis.gif"
+    src="the-image.jpg"
   />
 </div>
 `;
 
-exports[`Renaming props when passing to child components 1`] = `
-<div>
-  <span>
-    a gif
-  </span>
+exports[`Props selected from grandparent 1`] = `
+<div
+  className="outer"
+>
+  <div
+    className="outer-2"
+  >
+    <img
+      alt="The Image"
+      src="the-image.jpg"
+    />
+    <span>
+      The Image
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Props selected from parent 1`] = `
+<div
+  className="outer"
+>
   <img
-    alt="description: a gif"
-    src="awyis.gif"
+    alt="The Image"
+    src="the-image.jpg"
   />
+  <span>
+    The Image
+  </span>
+</div>
+`;
+
+exports[`Reducing a single prop with a transform function 1`] = `
+<div
+  className="root"
+>
+  <img
+    alt="The Image"
+    src="http://example.com/the-image.jpg"
+  />
+</div>
+`;
+
+exports[`Reducing multiple props with a transform function 1`] = `
+<div
+  className="root"
+>
+  <div
+    className="wrapper"
+  >
+    <img
+      alt="The Image"
+      src="http://example.com/the-image.jpg"
+    />
+  </div>
+</div>
+`;
+
+exports[`Reducing multiple props with a transform function 2`] = `
+<div
+  className="root"
+>
+  <div
+    className="wrapper"
+  >
+    <img
+      alt="The Image"
+      src="https://example.com/the-image.jpg"
+    />
+  </div>
 </div>
 `;

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -143,3 +143,51 @@ describe('Props', () => {
     expect(render(Outer)).toMatchSnapshot()
   })
 })
+
+describe('Reducing', () => {
+  it('a single prop with a transform function', () => {
+    const Root = x({
+      className: 'root',
+      imageUrl: 'the-image.jpg',
+      caption: 'The Image'
+    })
+
+    const Image = x.img({
+      src: x.from(Root.imageUrl, p => `http://example.com/${p.imageUrl}`),
+      alt: Root.caption
+    })
+
+    Root.children(Image)
+
+    expect(render(Root)).toMatchSnapshot()
+  })
+
+  it('multiple props with a transform function', () => {
+    const Root = x({
+      className: 'root',
+      imageUrl: 'the-image.jpg',
+      caption: 'The Image',
+      secure: false
+    })
+
+    const Wrapper = x({
+      className: 'wrapper'
+    })
+
+    const Image = x.img({
+      src: x.from(Root.imageUrl, Root.secure, p => (
+        `${p.secure ? 'https' : 'http'}://example.com/${p.imageUrl}`
+      )),
+      alt: Root.caption
+    })
+
+    Root.children(
+      Wrapper.children(
+        Image
+      )
+    )
+
+    expect(render(Root)).toMatchSnapshot()
+    expect(render(Root, { secure: true })).toMatchSnapshot()
+  })
+})

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -191,3 +191,25 @@ describe('Reducing', () => {
     expect(render(Root, { secure: true })).toMatchSnapshot()
   })
 })
+
+describe('Conditional rendering', () => {
+  it('using a child-function', () => {
+    const Root = x({
+      className: 'root',
+      imageUrl: '',
+      caption: ''
+    })
+
+    const Image = x.img({
+      src: Root.imageUrl,
+      alt: Root.caption
+    })
+
+    Root.children(
+      p => p.imageUrl && Image
+    )
+
+    expect(render(Root)).toMatchSnapshot()
+    expect(render(Root, { imageUrl: 'the-image.jpg' })).toMatchSnapshot()
+  })
+})

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,9 +1,8 @@
 /* global describe, it, expect */
 
-const x = require('../src')
-const renderer = require('react-test-renderer')
-const React = require('react')
-const { createElement } = React
+import x from '../src'
+import renderer from 'react-test-renderer'
+import React, { createElement } from 'react'
 
 function render (type, props) {
   return renderer.create(
@@ -13,108 +12,23 @@ function render (type, props) {
 
 describe('Classes', () => {
   it('with no classes', () => {
-    const Component = x.div()
+    const Component = x({})
     expect(render(Component)).toMatchSnapshot()
   })
 
   it('with a single class', () => {
-    const Component = x.div('some-class')
+    const Component = x({
+      className: 'some-class'
+    })
     expect(render(Component)).toMatchSnapshot()
   })
 
   it('with multiple classes', () => {
-    const Component = x.div('some-class', 'another-class')
+    const Component = x({
+      className: [
+        'some-class', 'another-class'
+      ]
+    })
     expect(render(Component)).toMatchSnapshot()
-  })
-})
-
-describe('Div with a conditional class', () => {
-  const Component = x.div(
-    'thing',
-    p => p.big ? 'thing--big' : [ 'thing--small', 'small' ]
-  )
-
-  it('gets a single extra class with the prop flag', () => {
-    expect(render(Component, { big: true })).toMatchSnapshot()
-  })
-
-  it('gets two extra classes without the prop flag', () => {
-    expect(render(Component)).toMatchSnapshot()
-  })
-})
-
-describe('Basic conditional rendering', () => {
-  const Component = x.div()
-    .renderIf('active')
-
-  it('with the prop flag', () => {
-    expect(
-      render(Component, { active: true, children: 'hi' })
-    ).toMatchSnapshot()
-  })
-
-  it('without the prop flag', () => {
-    expect(
-      render(Component, { children: 'hi' })
-    ).toMatchSnapshot()
-  })
-})
-
-describe('Conditional rendering by function', () => {
-  const Component = x.div()
-    .renderIf(p => p.a + p.b > 10)
-
-  it('with sum of props greater than 10', () => {
-    expect(
-      render(Component, { a: 9, b: 2, children: 'hi' })
-    ).toMatchSnapshot()
-  })
-
-  it('with sum of props less than 10', () => {
-    expect(
-      render(Component, { a: 1, b: 8, children: 'hi' })
-    ).toMatchSnapshot()
-  })
-})
-
-describe('Passing props', () => {
-  const Image = x.img()
-    .props(({ src, alt }) => ({ src, alt }))
-    .attr(({ src, alt }) => ({ src, alt }))
-
-  const Text = x.span()
-    .props(({ children }) => ({ children }))
-
-  const Component = x.div()
-    .content(
-      Text,
-      Image
-    )
-
-  it('passes props to child components', () => {
-    expect(
-      render(Component, { src: 'awyis.gif', alt: 'aw yis', children: 'a gif' })
-    ).toMatchSnapshot()
-  })
-})
-
-describe('Renaming props', () => {
-  const Image = x.img()
-
-  const Text = x.span()
-    .props(({ caption }) => ({ children: caption }))
-
-  const Component = x.div()
-    .content(
-      Text,
-      Image
-        .props(({ imageUrl, caption }) => ({ imageUrl, caption }))
-        .attr(({ imageUrl, caption }) => ({ src: imageUrl, alt: `description: ${caption}` }))
-    )
-
-  it('when passing to child components', () => {
-    expect(
-      render(Component, { imageUrl: 'awyis.gif', caption: 'a gif' })
-    ).toMatchSnapshot()
   })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -32,3 +32,50 @@ describe('Classes', () => {
     expect(render(Component)).toMatchSnapshot()
   })
 })
+
+describe('Attributes', () => {
+  it('not rendered on a wrapper component', () => {
+    const Component = x({
+      id: 'default-id',
+      'data-name': 'Default name'
+    })
+    expect(render(Component)).toMatchSnapshot()
+  })
+
+  it('rendered on an element', () => {
+    const Component = x.div({
+      id: 'default-id',
+      'data-name': 'Default name'
+    })
+    expect(render(Component)).toMatchSnapshot()
+  })
+
+  it('rendered on an element with parent props', () => {
+    const Component = x.div({
+      id: 'default-id',
+      'data-name': 'Default name'
+    })
+    expect(
+      render(Component, {
+        id: 'custom-id',
+        'data-name': 'Custom name'
+      })
+    ).toMatchSnapshot()
+  })
+
+  it('passed from wrapper component to element', () => {
+    const Component = x({
+      id: 'default-id',
+      'data-name': 'Default name'
+    })
+
+    Component.children(
+      x.span({
+        id: Component.id,
+        'data-attr': 'Other custom attr'
+      })
+    )
+
+    expect(render(Component)).toMatchSnapshot()
+  })
+})

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -31,6 +31,17 @@ describe('Classes', () => {
     })
     expect(render(Component)).toMatchSnapshot()
   })
+
+  it('with conditional classes', () => {
+    const Component = x({
+      className: [
+        'base-class',
+        p => p.big ? 'big' : 'small'
+      ]
+    })
+    expect(render(Component)).toMatchSnapshot()
+    expect(render(Component, { big: true })).toMatchSnapshot()
+  })
 })
 
 describe('Attributes', () => {
@@ -77,5 +88,58 @@ describe('Attributes', () => {
     )
 
     expect(render(Component)).toMatchSnapshot()
+  })
+})
+
+describe('Props', () => {
+  it('selected from parent', () => {
+    const Outer = x({
+      className: 'outer',
+      imageUrl: 'the-image.jpg',
+      caption: 'The Image'
+    })
+
+    const Inner1 = x.img({
+      src: Outer.imageUrl,
+      alt: Outer.caption
+    })
+
+    const Inner2 = x.span({
+      children: Outer.caption
+    })
+
+    Outer.children(Inner1, Inner2)
+
+    expect(render(Outer)).toMatchSnapshot()
+  })
+
+  it('selected from grandparent', () => {
+    const Outer = x({
+      className: 'outer',
+      imageUrl: 'the-image.jpg',
+      caption: 'The Image'
+    })
+
+    const Outer2 = x({
+      className: 'outer-2'
+    })
+
+    const Inner1 = x.img({
+      src: Outer.imageUrl,
+      alt: Outer.caption
+    })
+
+    const Inner2 = x.span({
+      children: Outer.caption
+    })
+
+    Outer.children(
+      Outer2.children(
+        Inner1,
+        Inner2
+      )
+    )
+
+    expect(render(Outer)).toMatchSnapshot()
   })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -2,7 +2,7 @@
 
 import x from '../src'
 import renderer from 'react-test-renderer'
-import React, { createElement } from 'react'
+import { createElement } from 'react'
 
 function render (type, props) {
   return renderer.create(

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,11 @@ function resolveProps (parent, source, props) {
     }
   })
 
+  // delete undefined props
+  Object.keys(newProps).forEach(k => {
+    if (newProps[k] === undefined) { delete newProps[k] }
+  })
+
   return newProps
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,6 @@ function collectDependencies (content, parent, result = {}) {
             if (ref.def === parent.def) {
               result[ref.key] = p
             }
-            return
           }
         })
       }
@@ -70,7 +69,6 @@ function collectDependencies (content, parent, result = {}) {
     .map(ch => ch.__x)
     .filter(Boolean)
     .forEach(collectFromDef)
-
 
   ensureArray(content)
     .map(ch => ch.__x_list)
@@ -139,7 +137,6 @@ function resolveProps (parent, source, props) {
 
       default:
         console.warn('Unknown propref type:', k, p)
-        return
     }
   })
 
@@ -213,7 +210,6 @@ function create (def) {
         // default: return the child as-is
         return ch
       }
-
 
       // children have already been resolved
       if (props.children && !def.changed.children) {
@@ -310,7 +306,6 @@ function create (def) {
       const children = this.getChildren(propsWithDefaults) || []
 
       if (!def.type) {
-        const { className } = propsWithDefaults
         const props = {}
         const keys = [ 'className', 'style' ]
         keys.forEach(k => {
@@ -351,7 +346,7 @@ function create (def) {
 
 const x = (props) => create({ props })
 
-x.from = (...refs) => ({  __x_from: refs })
+x.from = (...refs) => ({ __x_from: refs })
 
 x.list = (ref, component) => ({
   __x_list: { ref, component }

--- a/src/index.js
+++ b/src/index.js
@@ -273,7 +273,13 @@ function create (def) {
 
       if (!def.type) {
         const { className } = propsWithDefaults
-        const props = className ? { className } : {}
+        const props = {}
+        const keys = [ 'className', 'style' ]
+        keys.forEach(k => {
+          const v = propsWithDefaults[k]
+          if (v === undefined || v === null || v === '') { return }
+          props[k] = v
+        })
         return createElement('div', props, ...children)
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -236,10 +236,10 @@ function x (props) {
       // children get original props, not translated props
       const children = this.getChildren(propsWithDefaults) || []
 
-      const { className } = propsWithDefaults
-
       if (!def.type) {
-        return createElement('div', { className }, ...children)
+        const { className } = propsWithDefaults
+        const props = className ? { className } : {}
+        return createElement('div', props, ...children)
       }
 
       return createElement(def.type, propsWithDefaults, ...children)

--- a/src/index.js
+++ b/src/index.js
@@ -228,6 +228,24 @@ function create (def) {
         }
       })
 
+      // resolve x.from values
+      Object.keys(newProps).forEach(k => {
+        const from = newProps[k].__x_from
+        if (!from) { return }
+
+        newProps[k] = from.reduce((acc, value) => {
+          const ref = value.__x_ref
+          if (ref) {
+            acc[ref.key] = newProps[ref.key]
+            return acc
+          }
+
+          if (typeof value === 'function') {
+            return value(Object.assign({}, newProps, acc))
+          }
+        }, {})
+      })
+
       // special case: className
       if (newProps.className) {
         const join = (val) => Array.isArray(val) ? val.join(' ') : val

--- a/src/index.js
+++ b/src/index.js
@@ -122,12 +122,7 @@ function getProps (parent, def, props) {
 }
 
 // declare a component by its props
-function x (props) {
-  // component class definition
-  const def = {
-    props
-  }
-
+function create (def) {
   class DrxComponent extends PureComponent {
     constructor (props) {
       super(props)
@@ -136,8 +131,10 @@ function x (props) {
 
     getChild (Component, props) {
       const def = Component.__x
+
+      // children that are elements are created directly, with no wrapper
       return def.elem
-        ? Component(getProps(this, def, props))
+        ? createElement(def.type, getProps(this, def, props))
         : createElement(Component, getProps(this, def, props))
     }
 
@@ -251,7 +248,7 @@ function x (props) {
   c.__x = def
 
   // expose the prop references
-  Object.keys(props).forEach(k => {
+  Object.keys(def.props).forEach(k => {
     c[k] = new PropRef(c, k)
   })
 
@@ -263,21 +260,13 @@ function x (props) {
   return c
 }
 
-x.from = function (...refs) {
-  return { __x_from: refs }
-}
+const x = (props) => create({ props })
+
+x.from = (...refs) => ({  __x_from: refs })
 
 const types = Object.keys(DOM)
 types.forEach(type => {
-  x[type] = (def) => {
-    const func = createElement.bind(null, type)
-    func.__x = {
-      elem: true,
-      props: def
-    }
-
-    return func
-  }
+  x[type] = (props) => create({ type, props, elem: true })
 })
 
 export default x


### PR DESCRIPTION
Taking a different approach, based on things learned from the last few iterations.

Now the emphasis is on describing components and elements by the props they deal in, and declaring the dependencies & transformations between 1 set of props and another.

Syntax example:

```js
import x from 'drx'

const Root = x({
  imageUrl: '',
  caption: ''
})

const Image = x.img({
  src: Root.imageUrl,
  alt: Root.caption
})

const Caption = x.div({
  children: Root.caption
})

export default Root.children(
  Image,
  Caption
)
```
Still a lot of cleanup to do, tests to pass, and I need to try a lot more examples to make sure it's handling edge cases as expected.

